### PR TITLE
Fixed classpath issues for JUnit tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
   		<groupId>org.springframework</groupId>
   		<artifactId>spring-test</artifactId>
   		<version>3.2.3.RELEASE</version>
+  		<scope>test</scope>
   	</dependency>
   	<dependency>
   		<groupId>com.h2database</groupId>
@@ -146,11 +147,18 @@
 		<groupId>junit</groupId>
 		<artifactId>junit</artifactId>
 		<version>4.8.1</version>
+		<scope>test</scope>
 	</dependency>
 	<dependency>
 		<groupId>com.jayway.jsonpath</groupId>
 		<artifactId>json-path</artifactId>
 		<version>0.8.1</version>
+	</dependency>
+	<dependency>
+	    <groupId>javax.servlet</groupId>
+	    <artifactId>servlet-api</artifactId>
+	    <version>2.5</version>
+	    <scope>provided</scope>
 	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Added the servlet-api dependency as 'provided' scope, and changed a few test dependencies to 'test' scope. 'provided' scope means that the dependency is used at compile/test time, but not packaged with the resulting war (as it is "provided" by the webapp container's classpath). 'test' scope means that the dependency is only on the classpath during test time, and is not packaged with the war.
